### PR TITLE
HW-20-KUBERNETES-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,83 +1,9 @@
-# ** HW-19 - KUBERNETES-1 **
+# ** HW-20 - KUBERNETES-2 **
 
-Развернул мастер и воркер по инструкциям (сначала пытался на 18.04 установить, но были ошибки, на 20.04 все ок):
-1. Обновляем систему, импортируем ключи, ставим пакеты
-```
-# ALL
-apt update && apt upgrade -y && apt install mc htop wget curl net-tools apt-transport-https ca-certificates gnupg lsb-release
-# ALL - DOCKER INSTALL
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-apt update
-apt install docker-ce docker-ce-cli containerd.io docker-compose-plugin
-# ALL - KUBERNETES INSTALL
-sudo curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
-echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
-apt install kubelet kubeadm kubectl
-```
-2. Смотрим внешний адрес master и проводим инициализацию
-```
-sudo kubeadm init --apiserver-cert-extra-sans=51.250.76.199 --apiserver-advertise-address=0.0.0.0 --control-plane-endpoint=51.250.76.199 --pod-network-cidr=10.244.0.0/16
-```
-- При инцициализации возникла сошибка:
-```
-[preflight] Running pre-flight checks
-error execution phase preflight: [preflight] Some fatal errors occurred:
-	[ERROR CRI]: container runtime is not running: output: E0701 07:16:22.125652    4047 remote_runtime.go:925] "Status from runtime service failed" err="rpc error: code = Unimplemented desc = unknown service runtime.v1alpha2.RuntimeService"
-time="2022-07-01T07:16:22Z" level=fatal msg="getting status of runtime: rpc error: code = Unimplemented desc = unknown service runtime.v1alpha2.RuntimeService"
-, error: exit status 1
-[preflight] If you know what you are doing, you can make a check non-fatal with `--ignore-preflight-errors=...`
-To see the stack trace of this error execute with --v=5 or higher
-```
-- Решилось правкой конфига `/etc/containerd/config.toml` - нужно закоментировать строку `disabled_plugins = ["cri"]` и перезапустить службу `containerd`.
-- Проводим действия далее по инструкции:
-```
-mkdir -p $HOME/.kube
-sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
-sudo chown $(id -u):$(id -g) $HOME/.kube/config
-```
-- Запоминаем строку, которую будем использовать для подключения воркера
-```
-kubeadm join 51.250.76.199:6443 --token k7n61t.fz1bbfvf7mmqcylo --discovery-token-ca-cert-hash sha256:bba278433084cea8f14af7e838925345eff47d9234e7a6af71779e575846a5d0
-```
-3. На воркере выполняем (выполнилось без ошибок только после ребута сервера и правки конфига containerd):
-```
-kubeadm join 51.250.76.199:6443 --token k7n61t.fz1bbfvf7mmqcylo --discovery-token-ca-cert-hash sha256:bba278433084cea8f14af7e838925345eff47d9234e7a6af71779e575846a5d0
-```
-Получаем:
-```
-[kubelet-start] Starting the kubelet
-[kubelet-start] Waiting for the kubelet to perform the TLS Bootstrap...
-
-This node has joined the cluster:
-* Certificate signing request was sent to apiserver and a response was received.
-* The Kubelet was informed of the new secure connection details.
-
-Run 'kubectl get nodes' on the control-plane to see this node join the cluster.
-```
-- Проверяем ноды на мастере и получаем статус NotReady:
-```
-yc-user@master:~$ kubectl get nodes
-NAME     STATUS     ROLES           AGE    VERSION
-master   NotReady   control-plane   14m    v1.24.2
-worker   NotReady   <none>          5m2s   v1.24.2
-```
-3. Ставим сетевой плагин:
-```
-curl https://docs.projectcalico.org/v3.20/manifests/calico.yaml -o calico.yaml
-sudo nano calico.yaml
-# Раскомментируем (важно соблюсти отступы, иначе будет ошибка) 
-- name: CALICO_IPV4POOL_CIDR
-  value: "10.244.0.0/16"
-# Применяем
-kubectl apply -f calico.yaml
-```
-- Снова проверяем ноды - все ок!
-```
-yc-user@master:~$ kubectl get nodes
-NAME     STATUS   ROLES           AGE   VERSION
-master   Ready    control-plane   24m   v1.24.2
-worker   Ready    <none>          14m   v1.24.2
-yc-user@master:~$
-```
+1. Развернул локальный кластер kubernetes.
+Не знаю почему, но minikube по умолчанию выбрал vmware. При указании `–vm-driver=virtualbox` запустил в parallels =)
+Решилось следующей командой `minikube config set driver virtualbox` и соответстенно пересозданием minikube.
+2. Развернуто окружение kubernetes в YC
+3. Задеплоил приложения в k8s YC
+P.S. Скриншот приложен в PR.
+P.P.S. Уже после загрузки изменений в git обнаружил, что на 2 странице методички ветвь названа `kubernets-2` - перезалил изменения заново в правильную ветвь.

--- a/kubernetes/reddit/comment-deployment.yml
+++ b/kubernetes/reddit/comment-deployment.yml
@@ -2,18 +2,26 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: comment-deployment
+  name: comment
+  labels:
+    app: reddit
+    component: comment
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
-      app: comment
+      app: reddit
+      component: comment
   template:
     metadata:
       name: comment
       labels:
-        app: comment
+        app: reddit
+        component: comment
     spec:
       containers:
-      - image: alkolexx/comment
+      - image: chromko/comment
         name: comment
+        env:
+        - name: COMMENT_DATABASE_HOST
+          value: comment-db

--- a/kubernetes/reddit/comment-mongodb-service.yml
+++ b/kubernetes/reddit/comment-mongodb-service.yml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: comment-db
+  labels:
+    app: reddit
+    component: mongo
+    comment-db: "true"
+spec:
+  ports:
+  - port: 27017
+    protocol: TCP
+    targetPort: 27017
+  selector:
+    app: reddit
+    component: mongo
+    comment-db: "true"

--- a/kubernetes/reddit/comment-service.yml
+++ b/kubernetes/reddit/comment-service.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: comment
+  labels:
+    app: reddit
+    component: comment
+spec:
+  ports:
+  - port: 9292
+    protocol: TCP
+    targetPort: 9292
+  selector:
+    app: reddit
+    component: comment

--- a/kubernetes/reddit/dev-namespace.yml
+++ b/kubernetes/reddit/dev-namespace.yml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dev

--- a/kubernetes/reddit/mongo-deployment.yml
+++ b/kubernetes/reddit/mongo-deployment.yml
@@ -2,18 +2,33 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: mongo-deployment
+  name: mongo
+  labels:
+    app: reddit
+    component: mongo
+    comment-db: "true"
+    post-db: "true"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: mongo
+      app: reddit
+      component: mongo
   template:
     metadata:
       name: mongo
       labels:
-        app: mongo
+        app: reddit
+        component: mongo
+        comment-db: "true"
+        post-db: "true"
     spec:
       containers:
       - image: mongo:latest
         name: mongo
+        volumeMounts:
+        - name: mongo-persistent-storage
+          mountPath: /data/db
+      volumes:
+      - name: mongo-persistent-storage
+        emptyDir: {}

--- a/kubernetes/reddit/mongodb-service.yml
+++ b/kubernetes/reddit/mongodb-service.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb
+  labels:
+    app: reddit
+    component: mongo
+spec:
+  ports:
+  - port: 27017
+    protocol: TCP
+    targetPort: 27017
+  selector:
+    app: reddit
+    component: mongo

--- a/kubernetes/reddit/post-deployment.yml
+++ b/kubernetes/reddit/post-deployment.yml
@@ -2,18 +2,28 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: post-deployment
+  name: post
+  labels:
+    app: reddit
+    component: post
+    post-db: "true"
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
-      app: post
+      app: reddit
+      component: post
   template:
     metadata:
       name: post
       labels:
-        app: post
+        app: reddit
+        component: post
+        post-db: "true"
     spec:
       containers:
-      - image: alkolexx/post
+      - image: chromko/post
         name: post
+        env:
+        - name: POST_DATABASE_HOST
+          value: post-db

--- a/kubernetes/reddit/post-mongodb-service.yml
+++ b/kubernetes/reddit/post-mongodb-service.yml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: post-db
+  labels:
+    app: reddit
+    component: mongo
+    post-db: "true"
+spec:
+  ports:
+  - port: 27017
+    protocol: TCP
+    targetPort: 27017
+  selector:
+    app: reddit
+    component: mongo
+    post-db: "true"

--- a/kubernetes/reddit/post-service.yml
+++ b/kubernetes/reddit/post-service.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: post
+  labels:
+    app: reddit
+    component: post
+spec:
+  ports:
+  - port: 5000
+    protocol: TCP
+    targetPort: 5000
+  selector:
+    app: reddit
+    component: post

--- a/kubernetes/reddit/ui-deployment.yml
+++ b/kubernetes/reddit/ui-deployment.yml
@@ -1,19 +1,29 @@
 ---
 apiVersion: apps/v1
 kind: Deployment
-metadata:
-  name: ui-deployment
-spec:
-  replicas: 1
+metadata: # Блок метаданных деплоя
+  name: ui
+  labels:
+    app: reddit
+    component: ui
+spec: # Блок спецификации деплоя
+  replicas: 3
   selector:
     matchLabels:
-      app: ui
-  template:
+      app: reddit
+      component: ui
+  template: # Блок описания POD-ов
     metadata:
-      name: ui
+      name: ui-pod
       labels:
-        app: ui
+        app: reddit
+        component: ui
     spec:
       containers:
-      - image: alkolexx/ui
+      - image: chromko/ui
         name: ui
+        env:
+        - name: ENV
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace

--- a/kubernetes/reddit/ui-service.yml
+++ b/kubernetes/reddit/ui-service.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ui
+  labels:
+    app: reddit
+    component: ui
+spec:
+  type: NodePort
+  ports:
+  - port: 9292
+    protocol: TCP
+    targetPort: 9292
+  selector:
+    app: reddit
+    component: ui


### PR DESCRIPTION
# Выполнено ДЗ № 20 - KUBERNETES-2

1. Развернул локальный кластер kubernetes.
Не знаю почему, но minikube по умолчанию выбрал vmware. При указании `–vm-driver=virtualbox` запустил в parallels =)
Решилось следующей командой `minikube config set driver virtualbox` и соответстенно пересозданием minikube.
2. Развернуто окружение kubernetes в YC
3. Задеплоил приложения в k8s YC
P.S. Скриншот приложен в PR.
P.P.S. Уже после загрузки изменений в git обнаружил, что на 2 странице методички ветвь названа `kubernets-2` - перезалил изменения заново в правильную ветвь. На скриншоте ветвь не верная)
![screenshot](https://user-images.githubusercontent.com/4623765/177765977-f198d36d-ab04-4592-8360-82af4465a300.jpg)

